### PR TITLE
Update submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "fonts"]
 	path = fonts
-	url = git://github.com/shgysk8zer0/fonts.git
+	url = https://github.com/shgysk8zer0/fonts.git
 [submodule "img/octicons"]
 	path = img/octicons
-	url = git://github.com/primer/octicons.git
+	url = https://github.com/primer/octicons.git
 [submodule "js/std-js"]
 	path = js/std-js
-	url = git://github.com/shgysk8zer0/std-js.git
+	url = https://github.com/shgysk8zer0/std-js.git
 [submodule "css/normalize"]
 	path = css/normalize
-	url = git://github.com/necolas/normalize.css.git
+	url = https://github.com/necolas/normalize.css.git
 [submodule "img/logos"]
 	path = img/logos
-	url = git://github.com/shgysk8zer0/logos.git
+	url = https://github.com/shgysk8zer0/logos.git
 [submodule "css/core-css"]
 	path = css/core-css
-	url = git://github.com/shgysk8zer0/core-css.git
+	url = https://github.com/shgysk8zer0/core-css.git
 [submodule "img/svg-icons"]
 	path = img/svg-icons
-	url = git://github.com/shgysk8zer0/svg-icons.git
+	url = https://github.com/shgysk8zer0/svg-icons.git
 [submodule "img/adwaita-icons"]
 	path = img/adwaita-icons
-	url = git://github.com/shgysk8zer0/adwaita-icons.git
+	url = https://github.com/shgysk8zer0/adwaita-icons.git


### PR DESCRIPTION
GitHub pages do not support `git://`

## Description and issue

### List of significant changes made
-  
-  

